### PR TITLE
Fix bug where the content is not visible initially

### DIFF
--- a/Sources/UIHostingConfigurationBackport/UIHostingConfigurationBackport.swift
+++ b/Sources/UIHostingConfigurationBackport/UIHostingConfigurationBackport.swift
@@ -98,13 +98,7 @@ final class UIHostingContentViewBackport<Content, Background>: UIView, UIContent
 
   var configuration: UIContentConfiguration {
     didSet {
-      if let configuration = configuration as? UIHostingConfigurationBackport<Content, Background> {
-        hostingController.rootView = ZStack {
-          configuration.background
-          configuration.content
-        }
-        directionalLayoutMargins = configuration.margins
-      }
+      applyConfiguration()
     }
   }
 
@@ -147,6 +141,16 @@ final class UIHostingContentViewBackport<Content, Background>: UIView, UIContent
     } else {
       parentViewController?.addChild(hostingController)
       hostingController.didMove(toParent: parentViewController)
+    }
+  }
+
+  private func applyConfiguration() {
+    if let configuration = configuration as? UIHostingConfigurationBackport<Content, Background> {
+      hostingController.rootView = ZStack {
+        configuration.background
+        configuration.content
+      }
+      directionalLayoutMargins = configuration.margins
     }
   }
 }

--- a/Sources/UIHostingConfigurationBackport/UIHostingConfigurationBackport.swift
+++ b/Sources/UIHostingConfigurationBackport/UIHostingConfigurationBackport.swift
@@ -127,6 +127,8 @@ final class UIHostingContentViewBackport<Content, Background>: UIView, UIContent
       hostingController.view.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor),
       hostingController.view.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
     ])
+
+    applyConfiguration()
   }
 
   @available(*, unavailable)


### PR DESCRIPTION
When using the backport outside of the context of `UICollectionViewCell`, I noticed that the result of `makeContentView()` is an empty view. After setting `configuration` on that view the SwiftUI content appears.

This behavior is different from `UIHostingConfiguration`, which shows the SwiftUI content immediately.

This seems to be an oversight, because all it takes to fix this is to trigger the `didSet` block in the initializer.

